### PR TITLE
make this repo a module + add CI build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,7 +56,7 @@ jobs:
       
       - run: go build
 
-  go-test-windows:
+  go-build-windows:
     executor:
       name: win/vs2019
       shell: powershell.exe

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,82 @@
+version: 2.1
+
+orbs:
+  win: circleci/windows@1.0.0
+
+workflows:
+  workflow:
+    jobs:
+      - go-build:
+          name: Go 1.14
+          docker-image: circleci/golang:1.14
+          build-as-module: true
+      - go-build:
+          name: Go 1.13
+          docker-image: circleci/golang:1.13
+          build-as-module: true
+      - go-build:
+          name: Go 1.12
+          docker-image: circleci/golang:1.12
+      - go-build:
+          name: Go 1.11
+          docker-image: circleci/golang:1.11
+      - go-build:
+          name: Go 1.10
+          docker-image: circleci/golang:1.10
+      - go-build:
+          name: Go 1.9
+          docker-image: circleci/golang:1.9
+      - go-build:
+          name: Go 1.8
+          docker-image: circleci/golang:1.8
+      - go-build-windows:
+          name: Windows
+
+jobs:
+  go-build:
+    parameters:
+      docker-image:
+        type: string
+      build-as-module:
+        type: boolean
+        default: false
+
+    docker:
+      - image: <<parameters.docker-image>>
+
+    working_directory: /go/src/github.com/launchdarkly/go-ntlm-proxy-auth
+
+    steps:
+      - checkout
+
+      - unless:
+          condition: <<parameters.build-as-module>>
+          steps:
+            - run: go get -t .
+      
+      - run: go build
+
+  go-test-windows:
+    executor:
+      name: win/vs2019
+      shell: powershell.exe
+
+    environment:
+      GOPATH: C:\Users\VssAdministrator\go
+      PACKAGE_PATH: github.com/launchdarkly/go-ntlm-proxy-auth
+
+    steps:
+      - checkout
+      - run: go version
+      - run:
+          name: move source
+          command: |
+            go env GOPATH
+            mkdir ${env:GOPATH}\src\${env:PACKAGE_PATH}
+            mv * ${env:GOPATH}\src\${env:PACKAGE_PATH}
+      - run:
+          name: build and test
+          command: |
+            cd ${env:GOPATH}\src\${env:PACKAGE_PATH}
+            go get -t .
+            go test -v -race ./...

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![GoDoc](https://godoc.org/github.com/launchdarkly/go-ntlm-proxy-auth?status.svg)](https://godoc.org/github.com/launchdarkly/go-ntlm-proxy-auth)
+[![Circle CI](https://circleci.com/gh/launchdarkly/go-ntlm-proxy-auth.svg?style=svg)](https://circleci.com/gh/launchdarkly/go-ntlm-proxy-auth)
 
 With this package, you can connect to http/https servers protected by an NTLM proxy in Golang.
 

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,8 @@
+module github.com/launchdarkly/go-ntlm-proxy-auth
+
+go 1.13
+
+require (
+	github.com/launchdarkly/go-ntlmssp v0.0.0-20190601005913-a22bdd33b2a4
+	golang.org/x/crypto v0.0.0-20200604202706-70a84ac30bf9 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,9 @@
+github.com/launchdarkly/go-ntlmssp v0.0.0-20190601005913-a22bdd33b2a4 h1:r1FdPJK3SrnEKWrE8M1C57lxywsXTOdDTw8+cBaIhTI=
+github.com/launchdarkly/go-ntlmssp v0.0.0-20190601005913-a22bdd33b2a4/go.mod h1:rZQicBRNZBfM+eydZ8LNaQ0p9twUfP6T0hUzJFhaxM4=
+golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
+golang.org/x/crypto v0.0.0-20200604202706-70a84ac30bf9 h1:vEg9joUBmeBcK9iSJftGNf3coIG4HqZElCPehJsfAYM=
+golang.org/x/crypto v0.0.0-20200604202706-70a84ac30bf9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
+golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
+golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=


### PR DESCRIPTION
Since the major version is still 1, building and consuming it as a module doesn't require any changes to the import path. Therefore, it doesn't affect any consumers who are using dep or govendor. It just means that it's easier to pin the version of this dependency in a module-based project.